### PR TITLE
playing with p2p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### playing_with_p2p
 
 - in this branch I'm looking at a TcpMessageClient and an update to the registry and RegistryClient to support a generic element "info" that would contain information about the agent like maybe its IP address and port for receiving messages.
+- replaced the capabilities method with the info method so that lots of stuff can be incorporated into an agent's information packet maintained by the registry.
+
 
 ## Released
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### playing_with_p2p
+
+- in this branch I'm looking at a TcpMessageClient and an update to the registry and RegistryClient to support a generic element "info" that would contain information about the agent like maybe its IP address and port for receiving messages.
+
 ## Released
 
 ### [0.0.3] - 2024-12-08

--- a/docs/advanced_features.md
+++ b/docs/advanced_features.md
@@ -33,10 +33,15 @@ The AgentWatcher will:
 ### Example Implementation
 
 ```ruby
-class MyDynamicAgent < Agent99::Base
-  TYPE = :server
-  
-  def capabilities = ['my_capability']
+class MyDynamicAgent < Agent99::Base  
+  def info
+    {
+      # ...
+      type:         :server,
+      capabilities: ['my_capability'],
+      # ...
+    }
+  end
   
   def receive_request
     # Handle requests

--- a/docs/agent99_framework/message_client.md
+++ b/docs/agent99_framework/message_client.md
@@ -1,0 +1,120 @@
+# Message Client Documentation for Agent99 Framework
+
+## Overview
+
+The Message Client is a crucial component of the Agent99 Framework, providing an interface for agents to communicate with each other through a message broker. This document outlines the required methods and functionalities that should be implemented in any message client to ensure compatibility with the Agent99 Framework.
+
+## Message Format Requirements
+
+All messages sent and received through the Agent99 Framework must adhere to the following format requirements:
+
+1. **JSON Format**: All messages must be in JSON format. This ensures consistency and ease of parsing across different implementations and languages.
+
+2. **Header Element**: Each message must include a `header` element that conforms to the `HeaderSchema` defined for the Agent99 Framework. The `HeaderSchema` is as follows:
+
+```ruby
+class Agent99::HeaderSchema < SimpleJsonSchemaBuilder::Base
+  object do
+    string  :from_uuid,   required: true, examples: [SecureRandom.uuid]
+    string  :to_uuid,     required: true, examples: [SecureRandom.uuid]
+    string  :event_uuid,  required: true, examples: [SecureRandom.uuid]
+    string  :type,        required: true, examples: %w[request response control]
+    integer :timestamp,   required: true, examples: [Agent99::Timestamp.new.to_i]
+  end
+end
+```
+
+3. **Message Types**: The `type` field in the header must be one of: `request`, `response`, or `control`.
+
+4. **Validation**: All incoming messages are validated against the appropriate schema based on their type. If validation errors are found, an error response message is returned to the sender.
+
+## Class: MessageClient
+
+### Initialization
+
+```ruby
+def initialize(config: {}, logger: Logger.new($stdout))
+  # Implementation details...
+end
+```
+
+Creates a new instance of the MessageClient.
+
+- `config:` A hash containing configuration options for the message broker connection.
+- `logger:` A logger instance for output (default: stdout logger).
+
+### Public Methods
+
+#### setup
+
+```ruby
+def setup(agent_id:, logger:)
+  # Implementation details...
+end
+```
+
+Sets up the necessary resources for an agent to start communicating.
+
+- `agent_id:` The unique identifier for the agent.
+- `logger:` A logger instance for output.
+- Returns: An object representing the agent's message queue or channel.
+
+#### listen_for_messages
+
+```ruby
+def listen_for_messages(
+  queue,
+  request_handler:,
+  response_handler:,
+  control_handler:
+)
+  # Implementation details...
+end
+```
+
+Starts listening for incoming messages on the specified queue.
+
+- `queue:` The queue or channel object returned by the `setup` method.
+- `request_handler:` A callable object to handle incoming request messages.
+- `response_handler:` A callable object to handle incoming response messages.
+- `control_handler:` A callable object to handle incoming control messages.
+
+#### publish
+
+```ruby
+def publish(message:)
+  # Implementation details...
+end
+```
+
+Publishes a message to the specified queue.
+
+- `message:` A hash containing the message to be published. This must be in JSON format and include a header that conforms to the `HeaderSchema`.
+- Returns: A hash indicating the success or failure of the publish operation, including details if the message structure is invalid.
+
+#### delete_queue
+
+```ruby
+def delete_queue(queue_name:)
+  # Implementation details...
+end
+```
+
+Deletes the specified queue or cleans up resources associated with it.
+
+- `queue_name:` The name of the queue to be deleted.
+
+### Implementation Notes
+
+1. **Message Validation**: Implement thorough validation for all incoming and outgoing messages. Ensure that they are in JSON format and contain a header that conforms to the `HeaderSchema`. If validation fails for incoming messages, send an error response to the sender with details about the validation issues.
+
+2. **Error Handling**: Implement robust error handling for all methods, especially for connection, publishing, and validation errors.
+
+3. **Logging**: Provide detailed logging for all operations, including successful actions, validation results, and errors.
+
+4. **Performance and Scalability**: Optimize the client to handle a large number of JSON-formatted messages efficiently, considering potential performance impacts of validation.
+
+5. **Thread Safety**: Ensure that the client is thread-safe, particularly when handling message validation and publishing.
+
+By adhering to these requirements and implementing the MessageClient with these considerations, developers can ensure that their implementations will be fully compatible with the Agent99 Framework. The strict adherence to JSON formatting and the inclusion of a standardized header in all messages promotes consistency and reliability in inter-agent communication within the framework.
+

--- a/docs/agent_discovery.md
+++ b/docs/agent_discovery.md
@@ -12,17 +12,21 @@ The agent discovery process involves the following steps:
 2. **Discovery**: When an agent needs to discover other agents, it queries the registry for agents with specific capabilities.
 3. **Response**: The registry responds with a list of available agents, allowing them to interact based on their capabilities.
 
-### Declaring Capabilities
+### Declaring Capabilities in the Info Method
 
-Each agent must implement the `capabilities` method to declare its capabilities as an array of strings:
+Each agent must implement the `info` method to declare its capabilities as an array of strings:
 
 ```ruby
-def capabilities
-  ['process_image', 'face_detection']
+def info
+  {
+    # ...
+    capabilities:  ['process_image', 'face_detection'],
+    # ...
+  }
 end
 ```
 
-**Note**: The discovery mechanism is based on an exact match (case insensitive) between the requested capability and the entries in the agent's capabilities array. For example, if an agent declares its capabilities as mentioned above, a discovery request for `'FACE_DETECTION'` will successfully match.
+**Note**: The discovery mechanism is based on an exact match (case insensitive) between the requested capability and the entries in the agent's capabilities array in its information packet. For example, if an agent declares its capabilities as mentioned above, a discovery request for `'FACE_DETECTION'` will successfully match.
 
 ### Discovery API
 

--- a/docs/agent_registry_processes.md
+++ b/docs/agent_registry_processes.md
@@ -38,8 +38,14 @@ end
 # Define the new Agent ....
 
 class MyAgent < Agent99::Base
-  REQUEST_SCHEMA    = MyAgentRequest.schema
-  def capabilities  = %w[ greeter hello_world ]
+  def info
+    {
+      # ...
+      request_schema: MyAgentRequest.schema
+      capabilities:   %w[ greeter hello_world ],
+      # ...
+    }
+  end
 end
 
 # You may create multiple instances of the agent if needed

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -6,13 +6,23 @@ When creating a new agent by subclassing `Agent99::Base`, you must implement cer
 
 ### Required Methods
 
-#### `capabilities`
-Returns an array of strings describing the agent's capabilities.
+#### `info`
+ The `info` method provides a comprehensive information packet about the agent. It returns a hash containing key details that are crucial for agent registration and discovery within the system.
 ```ruby
-def capabilities
-  ['process_image', 'face_detection']
+def info
+  {
+    name:             self.class.to_s,
+    type:             :server,
+    capabilities:     %w[ greeter hello_world hello-world hello],
+    request_schema:   MaxwellRequest.schema,
+    # response_schema:  {}, # Agent99::RESPONSE.schema
+    # control_schema:   {}, # Agent99::CONTROL.schema
+    # error_schema:     {}, # Agent99::ERROR.schema
+  }
 end
 ```
+
+Entries for **:name** and **:capabilities** are required.  Other entries are optional.  This entire info packet is stored by the central registry and provided to other agents on a discover "hit" so that the inquiring agents know all the target agent is willing to tell them.
 
 #### `receive_request`
 Handles incoming request messages. Must be implemented if the agent accepts requests.

--- a/docs/what_is_an_agent.md
+++ b/docs/what_is_an_agent.md
@@ -44,11 +44,17 @@ Here's a simple example of an Agent99 agent class running in an independent proc
 require 'agent99'
 
 class ExampleAgent < Agent99::Base
-  TYPE = :server
-
-  def capabilities
-    %w[ rubber_stamp yes_man example noop always_succeed ]
-  end
+  def info
+    {
+      name:             self.class.to_s,
+      type:             :server,
+      capabilities:     %w[ rubber_stamp yes_man example ],
+      # request_schema:   {}, # ExampleRequest.schema,
+      # response_schema:  {}, # Agent99::RESPONSE.schema
+      # control_schema:   {}, # Agent99::CONTROL.schema
+      # error_schema:     {}, # Agent99::ERROR.schema
+    }
+  end  
 
   def receive_request
     logger.info "Example agent received request: #{payload}"
@@ -63,11 +69,11 @@ ExampleAgent.new.run
 ruby example_agent.rb
 ```
 
-Each agent subclass is responsible for specific methods that define its unique capabilities and how it handles requests. The capabilities method defines what things the agent can perform. Since we define a software agent below as code that does one thing, each entry in this Array of Strings is basically a synonym.
+Each agent subclass is responsible for specific methods that define its unique capabilities and how it handles requests.  The `info` method provides a comprehensive information packet about the agent. It returns a hash containing key details that are crucial for agent registration and discovery within the system.  The **:capabilities** entry in the `info` packet in an Array of Strings - synonyms - for the thing that the agent does.
 
-For a server type agent, the only methods that are required to be defined, as in the ExampleAgent class above, are its **capabilities** and its **receive_request** methods. Everything else from initialization, registration, message dispatching, and graceful shutdown are handled by the default methods within the **Agent99::Base** class.
+For a server type agent, the only methods that are required to be defined, as in the ExampleAgent class above, are its **info** and its **receive_request** methods. Everything else from initialization, registration, message dispatching, and graceful shutdown are handled by the default methods within the **Agent99::Base** class.
 
-More complex agents will require methods like **handle_response** and **handle_control** and potentially custom implementations of **init**, **initialize**, or **fini** may be necessary for managing state or resources.
+More complex agents will require methods like **receive_response** and **receive_control** and potentially custom implementations of **init**, **initialize**, or **fini** may be necessary for managing state or resources.
 
 > **RoadMap:** Currently, the Agent99 implementation defines the **capabilities** value as an `Array(String)`, with plans to enhance this functionality into descriptive unstructured text akin to defining tools for functional callbacks in LLM processing using semantic search.
 
@@ -247,12 +253,16 @@ require 'agent99'
 require_relative 'maxwell_request'
 
 class MaxwellAgent86 < Agent99::Base
-  REQUEST_SCHEMA = MaxwellRequest.schema
-  # ...
-end
+  def info
+    {
+      # ...
+      request_schema: MaxwellRequest.schema,
+      # ...
+    }
+  end
 ```
 
-When an agent subclass defines a **REQUEST_SCHEMA**, the message processing of the **Agent99::Base** validates all incoming requests against the schema. If there are errors, those errors are returned to the sender without presenting the request message to the agent's custom **receive_request** method.
+When an agent subclass defines a **:request_schema** in its `info`, the message processing of the **Agent99::Base** validates all incoming requests against the schema. If there are errors, those errors are returned to the sender without presenting the request message to the agent's custom **receive_request** method.
 
 #### Response Messages
 

--- a/examples/agent_watcher.rb
+++ b/examples/agent_watcher.rb
@@ -28,7 +28,11 @@ require_relative '../lib/agent99'
 class AgentWatcher < Agent99::Base
   TYPE = :client
 
-  def capabilities = %w[ launch_agents watcher launcher ]
+  def capabilities = {
+    info: {
+      capabilities: %w[ launch_agents watcher launcher ]
+    }
+  }
 
   def init
     @watch_path = ENV.fetch('AGENT_WATCH_PATH', './agents')

--- a/examples/chief_agent.rb
+++ b/examples/chief_agent.rb
@@ -85,7 +85,11 @@ class ChiefAgent < Agent99::Base
 
 
   def capabilities
-    ['Chief of Control']
+    {
+      info: {
+        capabilities: ['Chief of Control']
+      }
+    }
   end
 end
 

--- a/examples/chief_agent.rb
+++ b/examples/chief_agent.rb
@@ -14,7 +14,23 @@
 require_relative '../lib/agent99'
 
 class ChiefAgent < Agent99::Base
-  TYPE = :client
+  # this information is made available when the agent
+  # registers with the central registry service.  It is
+  # made available during the discovery process.
+  #
+  def info
+    {
+      name:             self.class.to_s,
+      type:             :client,
+      capabilities:     ['Chief of Control'],
+      # request_schema:   ChiefRequest.schema,
+      # response_schema:  {}, # Agent99::RESPONSE.schema
+      # control_schema:   {}, # Agent99::CONTROL.schema
+      # error_schema:     {}, # Agent99::ERROR.schema
+    }
+  end
+
+
 
   # init is called at the end of the initialization process.
   # It may be only something that a :client type agent would do.
@@ -81,15 +97,6 @@ class ChiefAgent < Agent99::Base
     puts
 
     exit(0)
-  end
-
-
-  def capabilities
-    {
-      info: {
-        capabilities: ['Chief of Control']
-      }
-    }
   end
 end
 

--- a/examples/control.rb
+++ b/examples/control.rb
@@ -15,7 +15,11 @@ class Control < Agent99::Base
 
 
   def capabilities
-    ['control', 'headquarters', 'secret underground base']
+    {
+      info: {
+        capabilities: ['control', 'headquarters', 'secret underground base']
+      }
+    }
   end
 
 

--- a/examples/control.rb
+++ b/examples/control.rb
@@ -4,22 +4,27 @@
 require_relative '../lib/agent99'
 
 class Control < Agent99::Base
-  TYPE = :hybrid
+  # this information is made available when the agent
+  # registers with the central registry service.  It is
+  # made available during the discovery process.
+  #
+  def info
+    {
+      name:             self.class.to_s,
+      type:             :hybrid,
+      capabilities:     ['control', 'headquarters', 'secret underground base'],
+      # request_schema:   ControlRequest.schema,
+      # response_schema:  {}, # Agent99::RESPONSE.schema
+      # control_schema:   {}, # Agent99::CONTROL.schema
+      # error_schema:     {}, # Agent99::ERROR.schema
+    }
+  end
 
   attr_accessor :statuses
 
   def init
     @agents = @registry_client.fetch_all_agents
     @statuses = {}
-  end
-
-
-  def capabilities
-    {
-      info: {
-        capabilities: ['control', 'headquarters', 'secret underground base']
-      }
-    }
   end
 
 

--- a/examples/example_agent.rb
+++ b/examples/example_agent.rb
@@ -17,7 +17,11 @@ require_relative '../../lib/agent99'
 class ExampleAgent < Agent99::Base
   TYPE = :server
   
-  def capabilities = %w[ rubber_stamp yes_man example ]
+  def capabilities = {
+    info: {
+      capabilities: %w[ rubber_stamp yes_man example ]
+    }
+  }
   
   def receive_request
     logger.info "Example agent received request: #{payload}"

--- a/examples/example_agent.rb
+++ b/examples/example_agent.rb
@@ -15,13 +15,22 @@
 require_relative '../../lib/agent99'
 
 class ExampleAgent < Agent99::Base
-  TYPE = :server
-  
-  def capabilities = {
-    info: {
-      capabilities: %w[ rubber_stamp yes_man example ]
+  # this information is made available when the agent
+  # registers with the central registry service.  It is
+  # made available during the discovery process.
+  #
+  def info
+    {
+      name:             self.class.to_s,
+      type:             :server,
+      capabilities:     %w[ rubber_stamp yes_man example ],
+      # request_schema:   {}, # ExampleRequest.schema,
+      # response_schema:  {}, # Agent99::RESPONSE.schema
+      # control_schema:   {}, # Agent99::CONTROL.schema
+      # error_schema:     {}, # Agent99::ERROR.schema
     }
-  }
+  end  
+
   
   def receive_request
     logger.info "Example agent received request: #{payload}"

--- a/examples/maxwell_agent86.rb
+++ b/examples/maxwell_agent86.rb
@@ -108,7 +108,11 @@ class MaxwellAgent86 < Agent99::Base
   # For now, lets just go with the Array of Strings.
   #
   def capabilities
-    %w[ greeter hello_world hello-world hello]   
+    {
+      info: {
+        capabilities: %w[ greeter hello_world hello-world hello]
+      }
+    }
   end
 end
 

--- a/examples/maxwell_agent86.rb
+++ b/examples/maxwell_agent86.rb
@@ -10,12 +10,21 @@ require_relative '../lib/agent99'
 require_relative 'maxwell_request'
 
 class MaxwellAgent86 < Agent99::Base
-  REQUEST_SCHEMA  = MaxwellRequest.schema
-  TYPE            = :server
-
-  # RESPONSE_SCHEMA = Agent99::RESPONSE.schema
-  # ERROR_SCHEMA    = Agent99::ERROR.schema
-
+  # this information is made available when the agent
+  # registers with the central registry service.  It is
+  # made available during the discovery process.
+  #
+  def info
+    {
+      name:             self.class.to_s,
+      type:             :server,
+      capabilities:     %w[ greeter hello_world hello-world hello],
+      request_schema:   MaxwellRequest.schema,
+      # response_schema:  {}, # Agent99::RESPONSE.schema
+      # control_schema:   {}, # Agent99::CONTROL.schema
+      # error_schema:     {}, # Agent99::ERROR.schema
+    }
+  end
 
   #######################################
   private
@@ -89,30 +98,6 @@ class MaxwellAgent86 < Agent99::Base
   # a response message.
   def receive_response(response)
     loger.warn("Unexpected response type message: response.inspect")
-  end
-
-
-  # Phase One Implementation is to do a search
-  # using the String#include? and the Array#include?
-  # methods.  If you want discrete word-based selection
-  # then use an Array of Strings to define the different
-  # things this agent can do.
-  #
-  # If you want to match on sub-strings then define the
-  # the capabilities as a String.
-  #
-  # Subsequent implementations may use a semantic search
-  # to find the agents to use in which case capabilities may
-  # be constrained to be a String.
-  #
-  # For now, lets just go with the Array of Strings.
-  #
-  def capabilities
-    {
-      info: {
-        capabilities: %w[ greeter hello_world hello-world hello]
-      }
-    }
   end
 end
 

--- a/examples/registry.rb
+++ b/examples/registry.rb
@@ -28,11 +28,19 @@ end
 post '/register' do
   request.body.rewind
   request_data  = JSON.parse(request.body.read, symbolize_names: true)
+  debug_me{[
+    :request_data
+  ]}
   agent_name    = request_data[:name]
   agent_uuid    = SecureRandom.uuid
   
+  debug_me{[
+    :agent_name,
+    :agent_uuid
+  ]}
+
   # Ensure capabilities are lowercase
-  request_data[:info][:capabilities].map!{|c| c.downcase}
+  request_data[:capabilities].map!{|c| c.downcase}
   
   AGENT_REGISTRY << request_data.merge({uuid: agent_uuid})
 
@@ -48,7 +56,7 @@ get '/discover' do
   capability = params['capability'].downcase
 
   matching_agents = AGENT_REGISTRY.select do |agent|
-    agent.dig(:info, :capabilities)&.include?(capability)
+    agent[:capabilities]&.include?(capability)
   end
 
   content_type :json

--- a/examples/registry.rb
+++ b/examples/registry.rb
@@ -27,13 +27,14 @@ end
 # Endpoint to register an agent
 post '/register' do
   request.body.rewind
-  agent_info = JSON.parse(request.body.read, symbolize_names: true)
-  agent_name = agent_info[:name]
-  agent_uuid = SecureRandom.uuid
-
-  agent_info[:capabilities].map!{|c| c.downcase}
-
-  AGENT_REGISTRY << agent_info.merge({uuid: agent_uuid})
+  request_data  = JSON.parse(request.body.read, symbolize_names: true)
+  agent_name    = request_data[:name]
+  agent_uuid    = SecureRandom.uuid
+  
+  # Ensure capabilities are lowercase
+  request_data[:info][:capabilities].map!{|c| c.downcase}
+  
+  AGENT_REGISTRY << request_data.merge({uuid: agent_uuid})
 
   status 201
   content_type :json
@@ -47,7 +48,7 @@ get '/discover' do
   capability = params['capability'].downcase
 
   matching_agents = AGENT_REGISTRY.select do |agent|
-    agent[:capabilities].include?(capability)
+    agent.dig(:info, :capabilities)&.include?(capability)
   end
 
   content_type :json

--- a/lib/agent99/agent_discovery.rb
+++ b/lib/agent99/agent_discovery.rb
@@ -32,4 +32,8 @@ module Agent99::AgentDiscovery
 
     all ? result : result.sample(how_many)
   end
+
+  def add_agent(agent_info)
+    @agents[agent_info[:uuid]] = agent_info
+  end
 end

--- a/lib/agent99/agent_lifecycle.rb
+++ b/lib/agent99/agent_lifecycle.rb
@@ -11,12 +11,13 @@ module Agent99::AgentLifecycle
   def initialize(registry_client: Agent99::RegistryClient.new,
                  message_client: Agent99::AmqpMessageClient.new,
                  logger: Logger.new($stdout))
-    @payload = nil
-    @name = self.class.name
-    @capabilities = capabilities
-    @id = nil
-    @registry_client = registry_client
-    @message_client = message_client
+    @agents           = {}
+    @payload          = nil
+    @name             = self.class.name
+    @capabilities     = capabilities
+    @id               = nil
+    @registry_client  = registry_client
+    @message_client   = message_client
     @logger = logger
 
     @registry_client.logger = logger

--- a/lib/agent99/base.rb
+++ b/lib/agent99/base.rb
@@ -37,7 +37,11 @@ class Agent99::Base
 
   MESSAGE_TYPES = %w[request response control]
 
-  attr_reader :id, :capabilities, :name, :payload, :header, :logger, :queue
+  attr_reader :id, :capabilities, :name
+  attr_reader :payload, :header, :queue
+  attr_reader :logger
+  attr_reader :agents
+  
   attr_accessor :registry_client, :message_client
 
 

--- a/lib/agent99/message_processing.rb
+++ b/lib/agent99/message_processing.rb
@@ -128,7 +128,9 @@ module Agent99::MessageProcessing
   # @return [Array] An array of validation errors, empty if validation succeeds
   #
   def validate_schema
-    schema = JsonSchema.parse!(self.class::REQUEST_SCHEMA)
+    return unless info[:request_schema]
+    
+    schema = JsonSchema.parse!(info[:request_schema])
     schema.expand_references!
     validator = JsonSchema::Validator.new(schema)
     

--- a/lib/agent99/registry_client.rb
+++ b/lib/agent99/registry_client.rb
@@ -16,8 +16,14 @@ class Agent99::RegistryClient
     @http_client = Net::HTTP.new(URI.parse(base_url).host, URI.parse(base_url).port)
   end
 
-  def register(name:, capabilities:)
-    request = create_request(:post, "/register", { name: name, capabilities: capabilities })
+  def register(name:, capabilities:, ip: nil, port: nil)
+    payload = { 
+      name: name, 
+      capabilities: capabilities,
+      ip: ip,
+      port: port
+    }.compact
+    request = create_request(:post, "/register", payload)
     @id = send_request(request)
   end
 

--- a/lib/agent99/registry_client.rb
+++ b/lib/agent99/registry_client.rb
@@ -16,12 +16,8 @@ class Agent99::RegistryClient
     @http_client  = Net::HTTP.new(URI.parse(base_url).host, URI.parse(base_url).port)
   end
 
-  def register(name:, capabilities:, **additional_info)
-    info = { capabilities: capabilities }.merge(additional_info)
-    payload = { 
-      name: name,
-      info: info
-    }
+  def register(info:)
+    payload = info
     request = create_request(:post, "/register", payload)
     @id     = send_request(request)
   end

--- a/lib/agent99/registry_client.rb
+++ b/lib/agent99/registry_client.rb
@@ -8,23 +8,22 @@ class Agent99::RegistryClient
   attr_accessor :logger
 
   def initialize(
-      base_url: ENV.fetch('REGISTRY_BASE_URL', 'http://localhost:4567'),
+      base_url: ENV.fetch('AGENT99_REGISTRY_URL', 'http://localhost:4567'),
       logger:   Logger.new($stdout)
     )
-    @base_url = base_url
-    @logger   = logger
-    @http_client = Net::HTTP.new(URI.parse(base_url).host, URI.parse(base_url).port)
+    @base_url     = base_url
+    @logger       = logger
+    @http_client  = Net::HTTP.new(URI.parse(base_url).host, URI.parse(base_url).port)
   end
 
-  def register(name:, capabilities:, ip: nil, port: nil)
+  def register(name:, capabilities:, **additional_info)
+    info = { capabilities: capabilities }.merge(additional_info)
     payload = { 
-      name: name, 
-      capabilities: capabilities,
-      ip: ip,
-      port: port
-    }.compact
+      name: name,
+      info: info
+    }
     request = create_request(:post, "/register", payload)
-    @id = send_request(request)
+    @id     = send_request(request)
   end
 
   def withdraw(id)
@@ -43,16 +42,16 @@ class Agent99::RegistryClient
 
 
   def fetch_all_agents
-    request = create_request(:get, "/")
-    response = send_request(request)
+    request   = create_request(:get, "/")
+    response  = send_request(request)
   end
 
   ################################################
   private
 
   def create_request(method, path, body = nil)
-    request = Object.const_get("Net::HTTP::#{method.capitalize}").new(path, { "Content-Type" => "application/json" })
-    request.body = body.to_json if body
+    request       = Object.const_get("Net::HTTP::#{method.capitalize}").new(path, { "Content-Type" => "application/json" })
+    request.body  = body.to_json if body
     request
   end
 

--- a/lib/agent99/tcp_message_client.rb
+++ b/lib/agent99/tcp_message_client.rb
@@ -1,4 +1,8 @@
 # lib/agent99/tcp_message_client.rb
+#
+# NOTE: This is an early attempt at a true
+#       peer-to-peer messaging platform.  Its not
+#       not ready for prime time.
 
 require 'socket'
 require 'json'
@@ -119,3 +123,61 @@ class Agent99::TcpMessageClient
     nil
   end
 end
+
+
+__END__
+
+Based on the provided code for the `Agent99::TcpMessageClient` class, here's an analysis of your questions:
+
+1. Does this class queue up JSON messages while a previous message is being processed?
+
+No, this class does not explicitly queue up JSON messages while a previous message is being processed. The class processes messages as they are received, without maintaining an internal queue. Each incoming message is handled in its own thread (see the `handle_client` method), which allows for concurrent processing of messages from multiple clients.
+
+2. Does it present a complete JSON message at once or does it only provide part of one?
+
+The class attempts to present complete JSON messages at once. Here's why:
+
+- In the `handle_client` method, messages are read using `client.gets`, which typically reads a full line of input (up to a newline character).
+- The received message is then parsed as JSON using `JSON.parse(message, symbolize_names: true)`.
+- If the parsing is successful, the entire parsed message is passed to the `route_message` method.
+
+However, there are a few potential issues to consider:
+
+- If a JSON message spans multiple lines, `client.gets` might not capture the entire message in one read.
+- There's no explicit handling for partial messages or message boundaries.
+- Large messages might be split across multiple TCP packets, and the current implementation doesn't account for reassembling these.
+
+To ensure complete message handling, you might want to consider implementing a more robust message framing protocol, such as using message length prefixes or delimiter-based framing.
+
+For example, you could modify the `handle_client` method to use a delimiter-based approach:
+
+```ruby
+def handle_client(client)
+  Thread.new do
+    buffer = ""
+    while @running
+      begin
+        chunk = client.readpartial(1024)
+        buffer += chunk
+        while (message_end = buffer.index("\n"))
+          message      = buffer[0...message_end]
+          buffer       = buffer[(message_end + 1)..]
+          parsed_message = JSON.parse(message, symbolize_names: true)
+          route_message(parsed_message)
+        end
+      rescue EOFError
+        break
+      rescue JSON::ParserError => e
+        @logger.error("Invalid JSON received: #{e.message}")
+      rescue StandardError => e
+        @logger.error("Error handling client: #{e.message}")
+        break
+      end
+    end
+    client.close unless client.closed?
+  end
+end
+```
+
+This modification would allow for handling of messages that might be split across multiple reads, ensuring that complete JSON messages are processed.
+

--- a/lib/agent99/tcp_message_client.rb
+++ b/lib/agent99/tcp_message_client.rb
@@ -1,0 +1,113 @@
+require 'socket'
+require 'json'
+require 'logger'
+
+class Agent99::TcpMessageClient
+  def initialize(logger: Logger.new($stdout))
+    @logger = logger
+    @server_socket = nil
+    @client_connections = {}
+    @handlers = {}
+    @running = false
+  end
+
+  def listen_for_messages(queue, request_handler:, response_handler:, control_handler:)
+    @handlers = {
+      request: request_handler,
+      response: response_handler,
+      control: control_handler
+    }
+    
+    start_server(queue[:port])
+  end
+
+  def publish(message)
+    target = message.dig(:header, :to)
+    return unless target
+
+    agent_info = discover_agent(target)
+    return unless agent_info
+
+    socket = connect_to_agent(agent_info[:ip], agent_info[:port])
+    return unless socket
+
+    begin
+      socket.puts(message.to_json)
+      true
+    rescue StandardError => e
+      @logger.error("Failed to send message: #{e.message}")
+      false
+    ensure
+      socket.close unless socket.closed?
+    end
+  end
+
+  def stop
+    @running = false
+    @server_socket&.close
+    @client_connections.each_value(&:close)
+    @client_connections.clear
+  end
+
+  private
+
+  def start_server(port)
+    @server_socket = TCPServer.new(port)
+    @running = true
+
+    Thread.new do
+      while @running
+        begin
+          client = @server_socket.accept
+          handle_client(client)
+        rescue StandardError => e
+          @logger.error("Server error: #{e.message}")
+        end
+      end
+    end
+  end
+
+  def handle_client(client)
+    Thread.new do
+      while @running
+        begin
+          message = client.gets
+          break if message.nil?
+
+          parsed_message = JSON.parse(message, symbolize_names: true)
+          route_message(parsed_message)
+        rescue JSON::ParserError => e
+          @logger.error("Invalid JSON received: #{e.message}")
+        rescue StandardError => e
+          @logger.error("Error handling client: #{e.message}")
+          break
+        end
+      end
+      client.close unless client.closed?
+    end
+  end
+
+  def route_message(message)
+    type = message.dig(:header, :type)&.to_sym
+    handler = @handlers[type]
+    
+    if handler
+      handler.call(message)
+    else
+      @logger.warn("No handler for message type: #{type}")
+    end
+  end
+
+  def discover_agent(agent_name)
+    # This would need to be implemented to work with your registry
+    # to look up the IP/port for the target agent
+    # Return format should be { ip: "1.2.3.4", port: 1234 }
+  end
+
+  def connect_to_agent(ip, port)
+    TCPSocket.new(ip, port)
+  rescue StandardError => e
+    @logger.error("Failed to connect to #{ip}:#{port}: #{e.message}")
+    nil
+  end
+end


### PR DESCRIPTION
- **AFW-116 Add Message Client documentation for Agent99**
- **`AFW-117 Add TcpMessageClient and enhance registry support`**
- **`AFW-118 Update message handling and agent registration logic`**
- **AFW-119 Refactor capabilities to structured format**
- **updated changelog**
- **`AFW-121 Refactor agent info handling and update documentation`**

The actual peer-to-peer messaging platform is still a major work in progress, at least I hope there is some progressing being made.  The primary change that this PR is bring is the new `info` method to replace the `capabilities` method.  This is a breaking change and will need to be documented.